### PR TITLE
fix(electron)

### DIFF
--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -17,7 +17,8 @@ function createWindow() {
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: path.join(__dirname, 'preload.js')
+      sandbox: false,
+      preload: path.join(__dirname, 'preload.mjs')
     },
     icon: path.join(__dirname, '../src/assets/icon.png')
   });

--- a/desktop/electron/preload.mjs
+++ b/desktop/electron/preload.mjs
@@ -47,3 +47,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getFileStatus: (hash) => ipcRenderer.invoke('content-get-file-status', hash)
   }
 });
+
+console.log('Preload script loaded'); // Add this line for debugging reaso

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "electron": "electron .",
-    "electron:dev": "concurrently \"npm run dev\" \"npm run electron\"",
+    "electron:dev": "concurrently \"npm run dev\" \"NODE_ENV=development npm run electron\"",
     "electron:build": "npm run build && electron-builder"
   },
   "keywords": [


### PR DESCRIPTION
Electron doesn't start because the preload file is not an ESM file and `sandbox` is not set to `false`.

I also added `NODE_ENV=development` to the start script, just to make sure it's really starting in `development` mode to handle things differently.